### PR TITLE
Changed double quote to single quote replacement with logic that changes

### DIFF
--- a/src/components/DataTable/DatasetTable.jsx
+++ b/src/components/DataTable/DatasetTable.jsx
@@ -11,13 +11,13 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
         for (const key in item) {
             if (Array.isArray(item[key])) {
                 // Convert objects to string representations
-                item[key] = item[key].map(element => (typeof element === 'object' ? JSON.stringify(element).replace(/"/g, "'") : element));
+                item[key] = item[key].map(element => (typeof element === 'object' ? JSON.stringify(element).replace(/"/g, '""') : element));
 
                 // Convert other arrays to comma-delimited strings
                 if (item[key].length < 2) {
                     item[key] = item[key][0].toString();
                 } else {
-                    item[key] = `"${item[key].join(', ')}"`;
+                    item[key] = `${item[key].join(', ')}`;
                 }
             }
         }


### PR DESCRIPTION
Small tweak to change where double quotes in an object were replaced with single quotes. Now a double quote is instead replaced with 2 double quotes to escape them. To go with this, the outer wrapping double quotes are removed. This seems to make csv's behave properly across excel, libre office spreadsheet etc. 