### PR TITLE
Changed double quote to single quote replacement with logic that changes

### DIFF
--- a/src/components/DataTable/DatasetTable.jsx
+++ b/src/components/DataTable/DatasetTable.jsx
@@ -11,13 +11,13 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
         for (const key in item) {
             if (Array.isArray(item[key])) {
                 // Convert objects to string representations
-                item[key] = item[key].map(element => (typeof element === 'object' ? JSON.stringify(element).replace(/"/g, "'") : element));
+                item[key] = item[key].map(element => (typeof element === 'object' ? JSON.stringify(element).replace(/"/g, '""') : element));
 
                 // Convert other arrays to comma-delimited strings
                 if (item[key].length < 2) {
                     item[key] = item[key][0].toString();
                 } else {
-                    item[key] = `"${item[key].join(', ')}"`;
+                    item[key] = `${item[key].join(', ')}`;
                 }
             }
         }


### PR DESCRIPTION
1 double quote to 2 double quotes. I also removed the double quotes that wrap the entire expression. This seems to make csv's read properly across multiple spreadsheet readers.

Following merged PR #135 for PROD