### PR TITLE
Remove logic for uniqueDataType on data_types - #133

### DIFF
--- a/src/components/DataTable/DatasetTable.jsx
+++ b/src/components/DataTable/DatasetTable.jsx
@@ -255,7 +255,7 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
             defaultSortOrder: defaultSortOrder["last_touch"] || null,
             sorter: (a,b) => new Date(a.last_touch) - new Date(b.last_touch),
             ellipsis: true,
-            render: (date, record) => <span>{(new Date(date).toLocaleString())}</span>
+            render: (date, record) => <span>{(new Date(`${date} UTC`).toLocaleString())}</span>
         },
         {
             title: "Has Contacts",

--- a/src/components/DataTable/DatasetTable.jsx
+++ b/src/components/DataTable/DatasetTable.jsx
@@ -37,17 +37,6 @@ const DatasetTable = ({ data, loading, handleTableChange, page, pageSize, sortFi
     const uniqueDatasetType = filterField('dataset_type')
     const uniqueSourceTypes = filterField('source_type')
     const uniqueHasRuiStates = filterField('has_rui_info')
-    const uniqueDataType = [...new Set(modifiedData.flatMap(item => {
-        if (Array.isArray(item.data_types)) {
-            if (item.data_types.length === 1) {
-                // For single-valued lists, convert to string
-                return item.data_types[0];
-            }
-            // Omit multi-valued ones
-            return [];
-        }
-        return item.data_types;
-    }))];
 
     let order = sortOrder;
     let field = sortField;

--- a/src/components/DataTable/UploadTable.jsx
+++ b/src/components/DataTable/UploadTable.jsx
@@ -234,7 +234,7 @@ const UploadTable = ({ data, loading, filterUploads, uploadData, datasetData, ha
                            bordered={false}
                            loading={loading}
                            pagination={{ position: ["topRight", "bottomRight"], current: page, defaultPageSize: pageSize}}
-                           scroll={{ x: 1000 }}
+                           scroll={{ x: 1500, y: 1500 }}
                            onChange={handleTableChange}
                            rowKey={TABLE.cols.f('id')}
                     />


### PR DESCRIPTION
Change log:
1. Remove unused logic related to `data_types`
2. Display UTC given timezone to user's local time
3. Match scroll settings on Datasets table to Uploads table