### PR TITLE
Remove mobile menu when not logged in since it is empty

### DIFF
--- a/src/components/AppBanner.jsx
+++ b/src/components/AppBanner.jsx
@@ -21,7 +21,9 @@ function AppBanner({name}) {
     }
 
     useEffect(() => {
-        const _banner = banners[name] || banners.default
+        const defaultBanner = banners.default || {}
+        let _banner = banners[name] || defaultBanner
+        _banner = Object.assign(_banner, defaultBanner)
         setBanner(_banner)
         if (_banner?.keepDismissed && localStorage.getItem(STORE_KEY)) {
             setDismissed(true)

--- a/src/components/AppNavBar.jsx
+++ b/src/components/AppNavBar.jsx
@@ -20,19 +20,17 @@ function AppNavBar() {
                         <span className='d-inline-block'>Data Ingest Board</span>
                     </h1>
                 </Navbar.Brand>
-                <Navbar.Toggle aria-controls="basic-navbar-nav"/>
-                <Navbar.Collapse className={'w-25 c-nav__auth'}>
+                {isAuthenticated && <Navbar.Toggle aria-controls="basic-navbar-nav"/>}
+                {isAuthenticated && <Navbar.Collapse className={'w-25 c-nav__auth'}>
                     <Nav className={'me-auto'}>
-                        {isAuthenticated && (
-                            <span className="c-logout">
-                                    <span className={'p-2 txt-muted-on-dark'}>{getUserEmail()}</span>
-                                    <button className="c-logout__btn" onClick={handleLogout}>
-                                        LOG OUT
-                                    </button>
-                                </span>
-                        )}
+                        <span className="c-logout">
+                            <span className={'p-2 txt-muted-on-dark'}>{getUserEmail()}</span>
+                            <button className="c-logout__btn" onClick={handleLogout}>
+                                LOG OUT
+                            </button>
+                        </span>
                     </Nav>
-                </Navbar.Collapse>
+                </Navbar.Collapse>}
             </Container>
         </Navbar>
     )


### PR DESCRIPTION
Add ability to extend banner config

Following merged PR #147 for PROD