### PR TITLE
Libpitt/22 derivedd

### DIFF
--- a/src/components/DataTable/UploadTable.jsx
+++ b/src/components/DataTable/UploadTable.jsx
@@ -1,27 +1,20 @@
 import {Button, Dropdown, Menu, Modal, Table, Tooltip} from "antd";
 import {CaretDownOutlined, DownloadOutlined} from "@ant-design/icons";
 import {CSVLink} from "react-csv";
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import Spinner from "../Spinner";
 import {ENVS, eq, TABLE, THEME, URLS} from "../../lib/helper";
 import ModalOver from "../ModalOver";
 
 const UploadTable = ({ data, loading, filterUploads, uploadData, datasetData, handleTableChange, page, pageSize, sortField, sortOrder, filters, className}) => {
-    const modifiedData = data.map(item => {
-        for (const key in item) {
-            if (Array.isArray(item[key])) {
-                // Convert objects to string representations
-                item[key] = item[key].map(element => (typeof element === 'object' ? JSON.stringify(element) : element));
-                // Convert other arrays to comma-delimited strings
-                if (item[key].length === 1) {
-                    item[key] = Array.isArray(item[key]) ? JSON.stringify(item[key]) : item[key];
-                } else {
-                    item[key] = item[key].join(', ');
-                }
-            }
-        }
-        return item;
-    })
+    const [rawData, setRawData] = useState([])
+    const [modifiedData, setModifiedData] = useState([])
+
+    useEffect(() => {
+        setRawData(JSON.parse(JSON.stringify(data)))
+        setModifiedData(TABLE.flattenDataForCSV(JSON.parse(JSON.stringify(data))))
+    }, [data])
+
     const [modalOpen, setModalOpen] = useState(false)
     const [modalBody, setModalBody] = useState(null)
     const unfilteredGroupNames = [...new Set(data.map(item => item.group_name))];
@@ -212,7 +205,7 @@ const UploadTable = ({ data, loading, filterUploads, uploadData, datasetData, ha
                     <Table className={`m-4 c-table--main ${countFilteredRecords(data, filters).length > 0 ? '' : 'no-data'}`}
                            columns={uploadColumns}
                            showHeader={!loading}
-                           dataSource={countFilteredRecords(modifiedData, filters)}
+                           dataSource={countFilteredRecords(rawData, filters)}
                            bordered={false}
                            loading={loading}
                            pagination={{ position: ["topRight", "bottomRight"], current: page, defaultPageSize: pageSize}}

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -116,7 +116,7 @@ const DataTable = (props) => {
 
     const addDescendants = (datasetResponse) => {
         return datasetResponse.map(dataset => {
-            const descendantsArray = dataset.descendant_datasets ? dataset.descendant_datasets.split(",") : [];
+            const descendantsArray = dataset.descendant_datasets  //eq(typeof dataset.descendant_datasets, 'string') ? dataset.descendant_datasets.split(",") : [];
             let descendant = "";
             if (descendantsArray.length === 1) {
                 descendant = descendantsArray[0];

--- a/src/components/ModalOverData.jsx
+++ b/src/components/ModalOverData.jsx
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types'
+import {Popover, Table} from "antd";
+import {TABLE, URLS} from "../lib/helper";
+import React from "react";
+import {ExportOutlined} from "@ant-design/icons";
+
+function ModalOverData({content, cols, setModalBody, setModalOpen, popoverText, args}) {
+    if (!content.length || !Array.isArray(content)) {
+        return <span>False</span>
+    }
+
+    const getColumns = () => {
+        if (cols.length) return cols;
+        return [
+            {
+                title: TABLE.cols.n('id'),
+                dataIndex: TABLE.cols.f('id'),
+                key: TABLE.cols.f('id'),
+                defaultSortOrder: args.defaultSortOrder[TABLE.cols.f('id')] || null,
+                sorter: (a,b) => a[TABLE.cols.f('id')].localeCompare(b[TABLE.cols.f('id')]),
+                ellipsis: true,
+                render: (id, record) => <a className={'lnk--ic'} href={URLS.ingest.view(record.uuid)} target="_blank" rel="noopener noreferrer">{id} <ExportOutlined /></a>
+            },
+            TABLE.reusableColumns(args.defaultSortOrder, args.defaultFilteredValue).status,
+            {
+                title: 'Creation Date',
+                dataIndex: 'created_timestamp',
+                key: 'created_timestamp',
+                sorter: (a,b) => new Date(a.created_timestamp) - new Date(b.created_timestamp),
+                render: (date, record) => <span>{(new Date(date).toLocaleString())}</span>
+            },
+        ]
+    }
+
+    return (
+        <>
+            <Popover content={popoverText} placement={'left'}><span onClick={() => {
+                setModalBody(<div>
+                    <h5 className='text-center mb-5'>Derived Datasets of {args.record[TABLE.cols.f('id')]}</h5>
+                    <Table rowKey={TABLE.cols.f('id')} dataSource={content} columns={getColumns()} />
+                </div>)
+                setModalOpen(true)
+            }
+            }>{content[0][TABLE.cols.f('id')]}...({content.length})</span></Popover>
+        </>
+    )
+}
+
+ModalOverData.defaultProps = {
+    popoverText: 'Click to view all derived datasets.',
+    cols: []
+}
+
+ModalOverData.propTypes = {
+    content: PropTypes.array.isRequired,
+    cols: PropTypes.array,
+    args: PropTypes.object.isRequired,
+    setModalBody: PropTypes.func.isRequired,
+    setModalOpen: PropTypes.func.isRequired
+}
+
+export default ModalOverData

--- a/src/components/ModalOverData.jsx
+++ b/src/components/ModalOverData.jsx
@@ -41,7 +41,7 @@ function ModalOverData({content, cols, setModalBody, setModalOpen, popoverText, 
                 </div>)
                 setModalOpen(true)
             }
-            }>{content[0][TABLE.cols.f('id')]}...({content.length})</span></Popover>
+            }>{content[0][TABLE.cols.f('id')]} {content.length > 1 ? `...(${content.length})` : ''}</span></Popover>
         </>
     )
 }

--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -1,3 +1,6 @@
+import {Tooltip} from "antd";
+import React from "react";
+
 export function eq(s1, s2, insensitive = true) {
     let res = s1 === s2
     if (insensitive && s1 !== undefined && s2 !== undefined) {
@@ -211,6 +214,57 @@ export const TABLE = {
             return true;
         });
         return filteredData;
+    },
+    flattenDataForCSV: (data) => {
+        return data.map(item => {
+            for (const key in item) {
+                if (Array.isArray(item[key])) {
+                    // Convert objects to string representations
+                    item[key] = item[key].map(element => (typeof element === 'object' ? JSON.stringify(element).replace(/"/g, '""') : element));
+
+                    // Convert other arrays to comma-delimited strings
+                    if (item[key].length < 2) {
+                        item[key] = Array.isArray(item[key]) ? JSON.stringify(item[key]) : item[key];
+                    } else {
+                        item[key] = `${item[key].join(', ')}`;
+                    }
+                }
+            }
+            return item;
+        })
+    },
+    reusableColumns: (defaultSortOrder, defaultFilteredValue) => {
+        return {
+            status: {
+                title: "Status",
+                width: 150,
+                dataIndex: "status",
+                align: "left",
+                defaultSortOrder: defaultSortOrder["status"] || null,
+                sorter: (a,b) => a.status.localeCompare(b.status),
+                defaultFilteredValue: defaultFilteredValue["status"] || null,
+                ellipsis: true,
+                filters: TABLE.getStatusFilters( [
+                    {text: 'Unpublished', value: 'unpublished'},
+                    {text: 'Published', value: 'published'},
+                    {text: 'QA', value: 'qa'}
+                ]),
+                onFilter: (value, record) => {
+                    if (eq(value, 'Unpublished')) {
+                        return !eq(record.status, 'published');
+                    }
+                    return eq(record.status, value);
+                },
+                render: (status) => (
+                    <Tooltip title={TABLE.getStatusDefinition(status)}>
+                    <span className={`c-badge c-badge--${status.toLowerCase()}`} style={{backgroundColor: THEME.getStatusColor(status).bg, color: THEME.getStatusColor(status).text}}>
+                        {status}
+                    </span>
+                    </Tooltip>
+
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Change log:
1. DRY `modifiedData` logic to helper `TABLE.flattenDataForCSV` .
2. Use `rawData` instead to correctly allow for building of table of `descendant_datasets`
3. Create `ModalOverData` component
4. Move status column object to helper in `TABLE.reusableColumns` for easy reuse in `ModalOverData`
5. Remove `UTC` string 

Requires:
https://github.com/sennetconsortium/ingest-api/pull/285 
https://github.com/hubmapconsortium/ingest-api/pull/482