### PR TITLE
Add '@' path alias for cleaner imports

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@/*": [
+                "src/*"
+            ]
+        }
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "**/.next",
+        "**/dist",
+        "**/log",
+        "**/node_modules",
+        "**/hubmap-docker",
+        "**/sennet-docker"
+    ]
+}

--- a/src/jsconfig.json
+++ b/src/jsconfig.json
@@ -1,7 +1,0 @@
-{
-  "compilerOptions": {
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  }
-}

--- a/src/next.config.js
+++ b/src/next.config.js
@@ -1,7 +1,24 @@
+const path = require('path')
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-   transpilePackages: [ 'antd', '@ant-design', 'rc-util', 'rc-tree', 'rc-table', 'rc-pagination', 'rc-picker', 'rc-notification', 'rc-tooltip' ]
+    reactStrictMode: true,
+    webpack: (config, options) => {
+        // Set the @ alias for the src directory
+        config.resolve.alias['@'] = path.resolve(__dirname)
+        return config
+    },
+    transpilePackages: [
+        'antd',
+        '@ant-design',
+        'rc-util',
+        'rc-tree',
+        'rc-table',
+        'rc-pagination',
+        'rc-picker',
+        'rc-notification',
+        'rc-tooltip'
+    ]
 }
 
 module.exports = nextConfig

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,9 +1,9 @@
-import '../styles/main.css'
+import '@/styles/main.css'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import { Roboto } from 'next/font/google'
-import { AppProvider } from '../context/AppContext'
-import useContent from "../hooks/useContent";
-import useGoogleTagManager from "../hooks/useGoogleTagMananger";
+import { AppProvider } from '@/context/AppContext'
+import useContent from "@/hooks/useContent";
+import useGoogleTagManager from "@/hooks/useGoogleTagMananger";
 
 const roboto = Roboto({
     weight: '500',


### PR DESCRIPTION
This shouldn't change anything. Path alias imports and relative imports can be used in the same project/file. I had to add the alias to the webpack config as well.

Changes
- Added path alias `@` for the `src` directory for cleaner imports 

Example 
```javascript
import { AppProvider } from '@/context/AppContext'
```