### PR TITLE
Libpitt/sankey

### DIFF
--- a/src/components/Visualizations/index.jsx
+++ b/src/components/Visualizations/index.jsx
@@ -57,18 +57,18 @@ function Visualizations({ data, filters, applyFilters, defaultColumn = 'group_na
         return values.sort((a, b) => b.value - a.value)
     }
 
-    const getColorFromUbkgPalette = (key, label, fallback) => {
-        return colorPalettes[key] && colorPalettes[key][label] ? colorPalettes[key][label] : scaleOrdinal(fallback)(label)
+    const getColorScale = (key, palette) => {
+        return colorPalettes && Object.keys(colorPalettes).length ? scaleOrdinal(Object.keys(colorPalettes[key]), Object.values(colorPalettes[key])) : scaleOrdinal(palette)
     }
 
     const applyColors = async () => {
 
         let _colorMethods = {
             ...colorMethods,
-            organ: ENVS.isHM() ? undefined : (label) =>  getColorFromUbkgPalette('organs', label, Palette.pinkColors),
+            organ: ENVS.isHM() ? undefined : getColorScale('organs', Palette.pinkColors),
             source_type: ENVS.isHM() ? undefined : scaleOrdinal(Palette.yellowColors),
-            dataset_type: ENVS.isHM() ? undefined :  (label) => getColorFromUbkgPalette('datasetTypes', label, Palette.greenColors),
-            group_name: ENVS.isHM() ? undefined :  (label) => getColorFromUbkgPalette('groups', label, Palette.blueGreyColors),
+            dataset_type: ENVS.isHM() ? undefined :  getColorScale('datasetTypes', Palette.greenColors),
+            group_name: ENVS.isHM() ? undefined :  getColorScale('groups', Palette.blueGreyColors),
 
         }
         setColorMethods(_colorMethods)

--- a/src/components/Visualizations/index.jsx
+++ b/src/components/Visualizations/index.jsx
@@ -15,6 +15,8 @@ import Pie from "@/components/Visualizations/Charts/Pie";
 import ENVS from '@/lib/helpers/envs';
 import {getHierarchy} from "@/lib/helpers/hierarchy";
 import {scaleOrdinal} from 'd3'
+import Palette from 'xac-sankey/dist/js/util/Palette'
+import useContent from "@/hooks/useContent";
 
 function Visualizations({ data, filters, applyFilters, defaultColumn = 'group_name' }) {
     const defaultChartTypes = ENVS.datasetCharts().reduce((acc, c) => {
@@ -28,6 +30,7 @@ function Visualizations({ data, filters, applyFilters, defaultColumn = 'group_na
     const [chartData, setChartData] = useState([])
     const [showModal, setShowModal] = useState(false)
     const [selectedFilterValues, setSelectedFilterValues] = useState([])
+    const { colorPalettes} = useContent()
 
     const getStatusColor = (label) => {
         return THEME.getStatusColor(label).bg
@@ -54,15 +57,18 @@ function Visualizations({ data, filters, applyFilters, defaultColumn = 'group_na
         return values.sort((a, b) => b.value - a.value)
     }
 
+    const getColorFromUbkgPalette = (key, label, fallback) => {
+        return colorPalettes[key] && colorPalettes[key][label] ? colorPalettes[key][label] : scaleOrdinal(fallback)(label)
+    }
 
     const applyColors = async () => {
-        const xac = await import('xac-sankey')
+
         let _colorMethods = {
             ...colorMethods,
-            organ: scaleOrdinal(xac.XACSankey.pinkColors()),
-            source_type: ENVS.isHM() ? undefined : scaleOrdinal(xac.XACSankey.yellowColors()),
-            dataset_type: ENVS.isHM() ? undefined : scaleOrdinal(xac.XACSankey.greenColors()),
-            group_name: ENVS.isHM() ? undefined : scaleOrdinal(xac.XACSankey.blueGreyColors()),
+            organ: ENVS.isHM() ? undefined : (label) =>  getColorFromUbkgPalette('organs', label, Palette.pinkColors),
+            source_type: ENVS.isHM() ? undefined : scaleOrdinal(Palette.yellowColors),
+            dataset_type: ENVS.isHM() ? undefined :  (label) => getColorFromUbkgPalette('datasetTypes', label, Palette.greenColors),
+            group_name: ENVS.isHM() ? undefined :  (label) => getColorFromUbkgPalette('groups', label, Palette.blueGreyColors),
 
         }
         setColorMethods(_colorMethods)

--- a/src/hooks/useContent.jsx
+++ b/src/hooks/useContent.jsx
@@ -7,6 +7,7 @@ function useContent() {
     const [messages, setMessages] = useState({})
     const [ubkg, setUbkg] = useState({})
     const [banners, setBanners] = useState({})
+    const [colorPalettes, setColorPalettes] = useState({})
 
     const loadMessages = async () => {
         let res = await axios.get(
@@ -29,6 +30,14 @@ function useContent() {
         return {}
     }
 
+    const loadColorPalettes = async () => {
+        let colors = await axios.get(
+            `https://x-atlas-consortia.github.io/ubkg-palettes/${ENVS.ubkg.sab().toLowerCase()}/palettes.json`,
+            getRequestOptions()
+        )
+        return colors.data
+    }
+
     const loadUbkg = async () => {
         let organTypes = await axios.get(
             `${ENVS.ubkg.base()}/organs?application_context=${ENVS.ubkg.sab()}`,
@@ -46,9 +55,10 @@ function useContent() {
         loadMessages().then((r) => setMessages(r))
         loadBanners().then((r) => setBanners(r))
         loadUbkg().then((r) => setUbkg(r))
+        loadColorPalettes().then((r) => setColorPalettes(r))
     }, [])
 
-    return {messages, ubkg, banners}
+    return {messages, ubkg, banners, colorPalettes}
 }
 
 

--- a/src/package.json
+++ b/src/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^18.3.1",
     "react-idle-timer": "^5.7.2",
     "stylus": "^0.59.0",
-    "xac-sankey": "github:x-atlas-consortia/data-sankey#1.0.10"
+    "xac-sankey": "github:x-atlas-consortia/data-sankey#1.0.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.7",

--- a/src/pages/sankey.js
+++ b/src/pages/sankey.js
@@ -5,7 +5,6 @@ import AppLogin from '@/components/AppLogin'
 import URLS from "@/lib/helpers/urls";
 import Spinner from "@/components/Spinner";
 import ENVS from "@/lib/helpers/envs";
-import {scaleOrdinal} from 'd3'
 
 function SankeyPage() {
     const {
@@ -36,11 +35,9 @@ function SankeyPage() {
         if (xacSankey.current && xacSankey.current.setOptions) {
             const el = xacSankey.current
             const adapter = isHM() ? new HuBMAPAdapter(el) : new SenNetAdapter(el)
-            if (!isHM()) {
-                el.theme.byScheme.dataset_group_name = scaleOrdinal(el.getColorPalettes().blueGrey)
-            }  else {
-                // clear the pink organs & leave HM to be its current randomized color until otherwise requested
-                el.theme.byScheme.organ_type = null
+            if (isHM()) {
+                // clear color settings & leave HM to be its current randomized color until otherwise requested
+                el.theme.byScheme = undefined
             }
             el.setOptions({
                 ...options,

--- a/src/pages/sankey.js
+++ b/src/pages/sankey.js
@@ -37,7 +37,10 @@ function SankeyPage() {
             const el = xacSankey.current
             const adapter = isHM() ? new HuBMAPAdapter(el) : new SenNetAdapter(el)
             if (!isHM()) {
-                el.theme.byScheme.dataset_group_name = scaleOrdinal(xac.XACSankey.blueGreyColors())
+                el.theme.byScheme.dataset_group_name = scaleOrdinal(el.getColorPalettes().blueGrey)
+            }  else {
+                // clear the pink organs & leave HM to be its current randomized color until otherwise requested
+                el.theme.byScheme.organ_type = null
             }
             el.setOptions({
                 ...options,
@@ -82,6 +85,7 @@ function SankeyPage() {
         if (globusToken && filters) {
             setOptions({
                 useShadow: true,
+                disableUbkgColorPalettes: isHM(),
                 styleSheetPath: '/css/xac-sankey.css',
                 filters,
                 groupByOrganCategoryKey: isHM() ? 'term' : undefined,


### PR DESCRIPTION
Change log:
1. Use https://x-atlas-consortia.github.io/ubkg-palettes/sennet/palettes.json generated palettes to keep colors consistent across ubkg terms. Otherwise will fallback to palettes within respective pink, green and blue grey.  HM remains untouched with settings `el.theme.byScheme = undefined` & `disableUbkgColorPalettes: isHM()`

Notice Blood is the same shade of pink on the other charts and sankey

AFTER:

![Screenshot 2025-05-16 at 1 27 55 PM](https://github.com/user-attachments/assets/1ede181f-6577-42db-8638-2d47c161cb26)
![Screenshot 2025-05-16 at 3 09 26 PM](https://github.com/user-attachments/assets/fadb26b5-a172-4f1a-8be6-00379b571605)
